### PR TITLE
feat: Add OPNetWebTransformer to embed in browser asc bundler

### DIFF
--- a/transformer/OPNetTransformer.ts
+++ b/transformer/OPNetTransformer.ts
@@ -37,12 +37,14 @@ logger.info('Compiling smart contract...');
 
 const abiCoder = new ABICoder();
 
-export default class MyTransform extends Transform {
+export { logger, SimpleParser };
+
+export default class OPNetTransformer extends Transform {
     // --------------------------------------------------
     // Per-class method info
     // --------------------------------------------------
-    private methodsByClass: Map<string, MethodCollection[]> = new Map();
-    private classDeclarations: Map<string, ClassDeclaration> = new Map();
+    protected methodsByClass: Map<string, MethodCollection[]> = new Map();
+    protected classDeclarations: Map<string, ClassDeclaration> = new Map();
 
     // --------------------------------------------------
     // Global event declarations (key = eventName)
@@ -170,7 +172,7 @@ export default class MyTransform extends Transform {
     // ------------------------------------------------------------
     //  Build final ABI per class
     // ------------------------------------------------------------
-    private buildAbiPerClass(): Map<string, ClassABI> {
+    protected buildAbiPerClass(): Map<string, ClassABI> {
         const result = new Map<string, ClassABI>();
 
         // For each known class, gather the methods
@@ -251,7 +253,7 @@ export default class MyTransform extends Transform {
     // ------------------------------------------------------------
     //  Generate .d.ts for each class
     // ------------------------------------------------------------
-    private buildDtsForClass(className: string, abiObj: ClassABI): string {
+    protected buildDtsForClass(className: string, abiObj: ClassABI): string {
         const interfaceName = `I${className}`;
 
         // 1) Event type definitions
@@ -361,7 +363,7 @@ export type ${typeName} = CallResult<
     // ------------------------------------------------------------
     //  Build the `execute` method stubs
     // ------------------------------------------------------------
-    private buildExecuteMethod(_className: string, methods: MethodCollection[]): string {
+    protected buildExecuteMethod(_className: string, methods: MethodCollection[]): string {
         const bodyLines: string[] = [];
 
         for (const m of methods) {
@@ -413,7 +415,7 @@ export type ${typeName} = CallResult<
       }`;
     }
 
-    private checkUnusedEvents(): void {
+    protected checkUnusedEvents(): void {
         /**
          * For each declared event:
          *   - see if it's used in ANY class (based on eventsUsedInClass)
@@ -445,7 +447,7 @@ export type ${typeName} = CallResult<
     // ------------------------------------------------------------
     //  AST Visitor
     // ------------------------------------------------------------
-    private visitStatement(stmt: Statement): void {
+    protected visitStatement(stmt: Statement): void {
         switch (stmt.kind) {
             case NodeKind.ClassDeclaration:
                 this.visitClassDeclaration(stmt as ClassDeclaration);

--- a/transformer/OPNetWebTransformer.ts
+++ b/transformer/OPNetWebTransformer.ts
@@ -1,0 +1,112 @@
+import OPNetTransformer, { SimpleParser, logger } from './OPNetTransformer.js';
+import { Parser, NodeKind, MethodDeclaration } from 'assemblyscript/dist/assemblyscript.js';
+
+import parserTypeScript from 'prettier/parser-typescript';
+import prettier from 'prettier/standalone';
+import prettierPluginEstree from 'prettier/plugins/estree';
+
+export default class OpnetWebTransformer extends OPNetTransformer {
+    private virtualFs: Map<string, string> = new Map();
+
+    public readFile(filename: string, baseDir: string): string | null {
+        return this.virtualFs.get(`${baseDir}/${filename}`) ?? null;
+    }
+
+    public writeFile(filename: string, contents: string | Uint8Array, baseDir: string): void {
+        this.virtualFs.set(`${baseDir}/${filename}`, contents.toString());
+        return;
+    }
+
+    public listFiles(dirname: string, baseDir: string): string[] | null {
+        const files: string[] = [];
+
+        for (const [key] of this.virtualFs.entries()) {
+            if (key.startsWith(`${baseDir}/${dirname}`)) {
+                files.push(key.replace(`${baseDir}/`, ''));
+            }
+        }
+
+        return files.length > 0 ? files : null;
+    }
+
+    public override async afterParse(parser: Parser): Promise<void> {
+        // 1) Parse AST
+        for (const source of parser.sources) {
+            if (source.isLibrary || source.internalPath.startsWith('~lib/')) {
+                continue;
+            }
+            for (const stmt of source.statements) {
+                this.visitStatement(stmt);
+            }
+        }
+
+        // 2) Build ABI per class
+        const abiMap = this.buildAbiPerClass();
+
+        // 4) Write one JSON + .d.ts per class
+        for (const [className, abiObj] of abiMap.entries()) {
+            if (abiObj.functions.length === 0) continue;
+
+            // JSON
+            const filePath = `abis/${className}.abi.json`;
+
+            this.writeFile(filePath, JSON.stringify(abiObj, null, 4), '.');
+
+            logger.success(`ABI generated to ${filePath}`);
+
+            // DTS
+            const dtsPath = `abis/${className}.d.ts`;
+            const dtsContents = this.buildDtsForClass(className, abiObj);
+            const formattedDts = await prettier.format(dtsContents, {
+                plugins: [parserTypeScript, prettierPluginEstree],
+                parser: 'typescript',
+                printWidth: 100,
+                trailingComma: 'all',
+                tabWidth: 4,
+                semi: true,
+                singleQuote: true,
+                quoteProps: 'as-needed',
+                bracketSpacing: true,
+                bracketSameLine: true,
+                arrowParens: 'always',
+                singleAttributePerLine: true,
+            });
+
+            this.writeFile(dtsPath, formattedDts, '.');
+            logger.success(`Type definitions generated to ${dtsPath}`);
+        }
+
+        // 5) Inject/overwrite `execute` in each relevant class
+        for (const [className, methods] of this.methodsByClass.entries()) {
+            if (!methods.length) continue;
+
+            logger.info(`Injecting 'execute' in class ${className}...`);
+            const classDecl = this.classDeclarations.get(className);
+            if (!classDecl) {
+                logger.warn(`ClassDeclaration not found for ${className}`);
+                continue;
+            }
+
+            const methodText = this.buildExecuteMethod(className, methods);
+            const newMember = SimpleParser.parseClassMember(methodText, classDecl);
+
+            // Overwrite if it exists
+            const existingIndex = classDecl.members.findIndex((member) => {
+                return (
+                    member.kind === NodeKind.MethodDeclaration &&
+                    (member as MethodDeclaration).name.text === 'execute'
+                );
+            });
+
+            if (existingIndex !== -1) {
+                logger.info(`Overwriting existing 'execute' in class ${className}`);
+                classDecl.members[existingIndex] = newMember;
+            } else {
+                classDecl.members.push(newMember);
+            }
+        }
+
+        // 6) Check for "unused" events and log warnings
+        this.checkUnusedEvents();
+    }
+}


### PR DESCRIPTION
Implements OPNetWebTransformer which extends OPNetTransformer and overrides the following methods:

readFile
writeFile
listFiles
as per: https://github.com/AssemblyScript/assemblyscript/blob/f16b08f691cd0002c0a5d303c5f290904d22cb68/cli/index.d.ts#L247

It maps these methods to a Map object, so that the asc compiler can read these files in the browser like if it were a filesystem.

Also overrides afterParse to use these new methods (rather than fs), and make adds plugins to prettier to make it work in standalone.