### PR TITLE
fix: sync OPNetWebTransform class with OPNetTransform

### DIFF
--- a/transform/OPNetTransform.ts
+++ b/transform/OPNetTransform.ts
@@ -40,7 +40,7 @@ const abiCoder = new ABICoder();
 
 export { logger, SimpleParser };
 
-function isAssemblyScriptStdLib(internalPath: string): boolean {
+export function isAssemblyScriptStdLib(internalPath: string): boolean {
     if (!internalPath.startsWith('~lib/')) return false;
     if (internalPath.includes('@')) return false;
     return !internalPath.includes('node_modules');

--- a/transform/OPNetWebTransform.ts
+++ b/transform/OPNetWebTransform.ts
@@ -1,6 +1,5 @@
-import OPNetTransform, { SimpleParser, logger } from './OPNetTransform.js';
+import OPNetTransform, { SimpleParser, logger, isAssemblyScriptStdLib } from './OPNetTransform.js';
 import { Parser, NodeKind, MethodDeclaration } from 'assemblyscript/dist/assemblyscript.js';
-
 import parserTypeScript from 'prettier/parser-typescript';
 import prettier from 'prettier/standalone';
 import prettierPluginEstree from 'prettier/plugins/estree';
@@ -30,17 +29,18 @@ export default class OpnetWebTransform extends OPNetTransform {
     }
 
     public override async afterParse(parser: Parser): Promise<void> {
-        // 1) Parse AST
+        // Parse AST
         for (const source of parser.sources) {
-            if (source.isLibrary || source.internalPath.startsWith('~lib/')) {
+            if (isAssemblyScriptStdLib(source.internalPath)) {
                 continue;
             }
+
             for (const stmt of source.statements) {
                 this.visitStatement(stmt);
             }
         }
 
-        // 2) Build ABI per class
+        // Build ABI per class
         const abiMap = this.buildAbiPerClass();
 
         // 4) Write one JSON + .d.ts per class


### PR DESCRIPTION
afterParse function on OPNetWebTransform didnt include some changes that were made on OPNetTransform in the past few months, causing stuff to break for consumers of OPNetWebTransform .

This PR fixes that.