### PR TITLE
Use @btc-vision/logger for Gulp logging

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,31 +1,55 @@
-import gulpESLintNew from 'gulp-eslint-new';
 import gulp from 'gulp';
 import gulpcache from 'gulp-cached';
 
 import gulpClean from 'gulp-clean';
-import logger from 'gulp-logger-new';
 import ts from 'gulp-typescript';
+import { Transform } from 'stream';
+import { Logger } from '@btc-vision/logger';
 
 process.on('uncaughtException', function (err) {
     console.log('Caught exception: ', err);
 });
+
+class GulpLogger extends Logger {
+    moduleName = 'Compiler';
+    logColor = '#4f77f9';
+}
+
+const logger = new GulpLogger();
+
+function onError(e) {
+    logger.error(String(e));
+}
+
+function logPipe(before, after, extname) {
+    let started = false;
+    return new Transform({
+        objectMode: true,
+        transform(file, _enc, cb) {
+            if (!started) {
+                logger.log(before);
+                started = true;
+            }
+            if (file.relative) {
+                logger.log(`${file.relative}${extname ? ` -> ${extname}` : ''}`);
+            }
+            cb(null, file);
+        },
+        flush(cb) {
+            logger.success(after);
+            cb();
+        },
+    });
+}
 
 const tsProject = ts.createProject('tsconfig.json');
 
 function buildESM() {
     return tsProject
         .src()
+        .on('error', onError)
         .pipe(gulpcache('ts-esm'))
-        .pipe(
-            logger({
-                before: 'Starting...',
-                after: 'Project compiled!',
-                extname: '.js',
-                showChange: true,
-            }),
-        )
-        .pipe(gulpESLintNew())
-        .pipe(gulpESLintNew.format())
+        .pipe(logPipe('Starting...', 'Project compiled!', '.js'))
         .pipe(tsProject())
         .pipe(gulp.dest('build'));
 }

--- a/package.json
+++ b/package.json
@@ -1,20 +1,20 @@
 {
     "name": "@btc-vision/opnet-transform",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "private": false,
     "description": "OP_NET AssemblyScript transform",
     "main": "build/OPNetTransform.js",
     "types": "std/assembly/index.d.ts",
     "typings": "std/assembly/index.d.ts",
     "scripts": {
-        "build": "gulp",
+        "build": "eslint transform/ && gulp",
         "test": "vitest run"
     },
     "author": "OPNet Labs",
     "license": "MIT",
     "devDependencies": {
-        "@types/node": "^25.2.3",
-        "vitest": "^4.0.18"
+        "@types/node": "^25.5.0",
+        "vitest": "^4.1.0"
     },
     "keywords": [
         "bitcoin",
@@ -31,29 +31,26 @@
     "homepage": "https://opnet.org",
     "type": "module",
     "peerDependencies": {
-        "@btc-vision/assemblyscript": "^0.29.2",
         "@btc-vision/visitor-as": "^0.12.1"
     },
     "dependencies": {
-        "@assemblyscript/loader": "^0.28.9",
-        "@btc-vision/assemblyscript": "^0.29.2",
-        "@btc-vision/bitcoin": "^7.0.0-rc.4",
+        "@btc-vision/as-loader": "^0.0.0",
+        "@btc-vision/assemblyscript": "^0.29.3",
+        "@btc-vision/bitcoin": "^7.0.0",
         "@btc-vision/logger": "^1.0.8",
-        "@btc-vision/transaction": "^1.8.0-rc.3",
+        "@btc-vision/transaction": "^1.8.2",
         "@btc-vision/visitor-as": "^0.12.1",
         "@eslint/js": "^10.0.1",
-        "eslint": "^10.0.0",
+        "eslint": "^10.0.3",
         "gulp": "^5.0.1",
         "gulp-cached": "^1.1.1",
         "gulp-clean": "^0.4.0",
-        "gulp-eslint-new": "^2.6.0",
-        "gulp-logger-new": "^1.0.1",
         "gulp-typescript": "^6.0.0-alpha.1",
-        "jsonrepair": "^3.13.2",
-        "opnet": "^1.8.1-rc.2",
+        "jsonrepair": "^3.13.3",
+        "opnet": "^1.8.6",
         "prettier": "^3.8.1",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.56.0"
+        "typescript-eslint": "^8.57.1"
     }
 }


### PR DESCRIPTION
Replace custom gulp logging utilities with a GulpLogger based on @btc-vision/logger and a reusable logPipe Transform. Add onError handling on the tsProject stream and remove the previous gulp-logger-new usage. Update build pipeline to emit concise start/file/finish logs and remove gulp-eslint-new invocation from the pipeline.

Also bump package version to 1.2.1, change the build script to run eslint against transform/ before gulp, and update several dependency versions (notable changes: add @btc-vision/as-loader, upgrade @btc-vision/assemblyscript, @btc-vision/bitcoin, @btc-vision/transaction, opnet, eslint, vitest, @types/node, and others). Remove gulp-eslint-new and gulp-logger-new from dependencies.